### PR TITLE
potential workflow improvements

### DIFF
--- a/.github/workflows/minifyAndPush.yml
+++ b/.github/workflows/minifyAndPush.yml
@@ -1,0 +1,39 @@
+name: Minify and Push
+
+env:
+  NODE_VERSION: 14.13.0
+
+on:
+  push:
+    branches: [ master ]
+    paths: [ 'canvas-where-am-i.*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm install
+      - run: npm run minify-prod
+      - run: echo "TOKEN=$(echo $(echo ${{ github.actor }} | tr '[:lower:]' '[:upper:]')"_API_TOKEN_GITHUB")" >> $GITHUB_ENV
+      - uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets[env.TOKEN] }}
+        with:
+          source_file: 'minified/.'
+          destination_repo: 'oxctl/canvas-theme'
+          user_email: ${{ github.event.pusher.email }}
+          user_name: ${{ github.event.pusher.name }}
+          commit_message: ${{ github.event.head_commit.message }} + ' (automated push from where-am-i)'
+

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Then startup the local webserver that will response to requests.
 
 There is then a file, [development.js](./development.js) that should be added to your theme as a JavaScript file which will dynamically add JS/CSS from your local webserver to Canvas. 
 
+# Deployment
+
+Oxctl includes these files as part of its Canvas Theme. On a push to master, if **`canvas-where-am-i.js`** or **`canvas-where-am-i.css`** have changed, a workflow will push minified versions of those files to the [*canvas-theme*](https://github.com/oxctl/canvas-theme) repository. In order for this to work, the user who pushed the changes needs to have a [Personal Access Token](https://github.com/settings/tokens) set as a secret, with the name `{USERNAME_UPPERCASE}_API_TOKEN_GITHUB`.
+
 # Problems
 Please report these as Issues and I will try and sort them out as soon as possible
 

--- a/canvas-where-am-I.js
+++ b/canvas-where-am-I.js
@@ -4,13 +4,28 @@
     /**** Start of Configuration Section ****/
     /****************************************/
 
-    let amazonS3bucketUrl = '';
+    // these are the urls from account-tools, but I can't work out how they relate to the different environments:
+    // const TEST = 'http://localhost'
+    // const LOCAL = 'https://localhost:3000'
+    // const DEV = 'https://static-dev.canvas.ox.ac.uk'
+    // const PROD = 'https://static.canvas.ox.ac.uk'
+
     /* Amazon S3 bucket URL, this URL is needed to retrieve the course presentation and navigation settings */
-    // amazonS3bucketUrl = 'https://oxctl-cpn-config-dev.s3-eu-west-1.amazonaws.com'
-    // The production bucket
-    // amazonS3bucketUrl = 'https://oxctl-cpn-config-prod.s3-eu-west-1.amazonaws.com'
-    // The development bucket
-    amazonS3bucketUrl = 'https://oxctl-modules-dev.s3-eu-west-1.amazonaws.com'
+    let amazonS3bucketUrl = '';
+    switch(window.location.origin){
+        case 'https://universityofoxford.beta.instructure.com':
+            // The development bucket
+            amazonS3bucketUrl = 'https://oxctl-cpn-config-dev.s3-eu-west-1.amazonaws.com';
+            break;
+        case 'https://canvas.ox.ac.uk':
+            // The production bucket
+            amazonS3bucketUrl = 'https://oxctl-cpn-config-prod.s3-eu-west-1.amazonaws.com';
+            break;
+        default:
+            // this is the default as needed for tests where window isn't available?
+            amazonS3bucketUrl = 'https://oxctl-modules-dev.s3-eu-west-1.amazonaws.com';
+    }
+
 
     /****************************************/
     /**** End of Configuration Section ****/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest cpn-general.test.js cpn-current-script.test.js cpn-empty-course.test.js",
     "test-deployed": "jest cpn-deployed-script.test.js",
     "start": "http-server -p 3001 -S -C localhost.pem -K localhost-key.pem",
-    "minify": "minify canvas-where-am-I.js --out-file canvas-where-am-I.min.js --mangle.keepClassName && cleancss -o canvas-where-am-I.min.css canvas-where-am-I.css"
+    "minify": "minify canvas-where-am-I.js --out-file canvas-where-am-I.min.js --mangle.keepClassName && cleancss -o canvas-where-am-I.min.css canvas-where-am-I.css",
+    "minify-prod": "mkdirp minified && minify important.js --out-file minified/important.min.js --mangle.keepClassName && cleancss -o minified/important.min.css important.css"
   },
   "repository": {
     "type": "git",
@@ -27,6 +28,7 @@
     "http-server": "^13.0.1",
     "jest": "^27.0.6",
     "jest-puppeteer": "^5.0.4",
+    "mkdirp": "^1.0.4",
     "puppeteer": "^5.3.1"
   },
   "jest": {


### PR DESCRIPTION
The idea behind this is:
When changes to where-am-i js or css files are merged to master, the minified versions are pushed to canvas-theme (as we have to do this manually anyway).
Relies on the pusher having a PAT stored in secrets, correctly named (see readme), which is a bit convoluted.
Other options possibly include having a set person to merge the changes, and having the action always use that username (or dynamically retrieve from "actor" property)
Or, a separate account which solely deals with automated requests.

Thoughts?